### PR TITLE
Fix syntax error in Mermaid diagram

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -50,9 +50,11 @@ stateDiagram-v2
     generatingVersions --> validating: VERSIONS_GENERATED
     validating --> completed: VALIDATION_PASSED
     validating --> checkingRetries: VALIDATION_FAILED
+
     state checkingRetries <<choice>>
-    checkingRetries --> regeneratingWithConstraints: retryCount_less_3
-    checkingRetries --> failed: retryCount_greater_equal_3
+    checkingRetries --> regeneratingWithConstraints: [retryCount < 3]
+    checkingRetries --> failed: [retryCount >= 3]
+
     regeneratingWithConstraints --> generatingVersions: RETRY
     completed --> [*]
     failed --> idle: RESET

--- a/docs/state-machines-visualization.md
+++ b/docs/state-machines-visualization.md
@@ -114,8 +114,8 @@ stateDiagram-v2
     validating --> checkingRetries: VALIDATION_FAILED
 
     state checkingRetries <<choice>>
-    checkingRetries --> regeneratingWithConstraints: retryCount_less_3
-    checkingRetries --> failed: retryCount_greater_equal_3
+    checkingRetries --> regeneratingWithConstraints: [retryCount < 3]
+    checkingRetries --> failed: [retryCount >= 3]
 
     regeneratingWithConstraints --> generatingVersions: RETRY
 


### PR DESCRIPTION
- Changed condition labels from underscore format to bracket notation
- Updated retryCount_less_3 to [retryCount < 3]
- Updated retryCount_greater_equal_3 to [retryCount >= 3]
- Added spacing for better readability
- Ensures compatibility with Mermaid v10.9.5 syntax requirements