### PR TITLE
Fix GitHub Pages deployment artifact issue

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -76,13 +76,11 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
           name: build-artifacts
+          path: ./artifacts
 
       - name: Setup Pages
         uses: actions/configure-pages@v4
@@ -90,7 +88,7 @@ jobs:
       - name: Upload artifact to Pages
         uses: actions/upload-pages-artifact@v3
         with:
-          path: 'docs/'
+          path: './artifacts/docs'
 
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
The deploy job was uploading source docs instead of built docs because:
- Checkout was overriding the artifact download location
- Artifact download path was not explicitly specified
- Upload path referenced the wrong docs directory

Changes:
- Removed unnecessary checkout step from deploy job
- Added explicit artifact download path (./artifacts)
- Updated Pages upload to use ./artifacts/docs

This ensures the generated documentation (916KB, 803 files) is deployed instead of just source files (120KB, 1 file).

Fixes GitHub Pages deployment issue where wrong artifact was uploaded.