### PR TITLE
Fix broken machine links

### DIFF
--- a/docs-astro/src/components/CategoryBadge.astro
+++ b/docs-astro/src/components/CategoryBadge.astro
@@ -6,7 +6,7 @@ interface Props {
 const { category } = Astro.props;
 ---
 
-<a href={`${import.meta.env.BASE_URL}category/${category}`} class="category-badge">
+<a href={`${import.meta.env.BASE_URL}/category/${category}`} class="category-badge">
   {category}
 </a>
 

--- a/docs-astro/src/pages/category/[slug].astro
+++ b/docs-astro/src/pages/category/[slug].astro
@@ -40,7 +40,7 @@ const { category, machines, allCategories } = Astro.props;
 
   <div class="machines-grid">
     {machines.map(machine => (
-      <a href={`${import.meta.env.BASE_URL}machine/${machine.id}`} class="machine-card">
+      <a href={`${import.meta.env.BASE_URL}/machine/${machine.id}`} class="machine-card">
         <h3>{machine.name}</h3>
         <p>{machine.description || 'No description available'}</p>
         <div class="machine-stats">


### PR DESCRIPTION
- Add missing "/" between BASE_URL and path segments in CategoryBadge component
- Add missing "/" between BASE_URL and machine path in category page
- Ensures proper URL formation when BASE_URL is set