### PR TITLE
Fix duplicate machine IDs in visualization system

### DIFF
--- a/src/__tests__/mermaid-syntax.test.ts
+++ b/src/__tests__/mermaid-syntax.test.ts
@@ -128,7 +128,7 @@ describe('Mermaid Syntax Validation', () => {
         const blocks = extractMermaidBlocks(filePath);
         const stateDiagramBlocks = blocks.filter(({ block }) => block.includes('stateDiagram'));
 
-        stateDiagramBlocks.forEach(({ block, lineStart }, index) => {
+        stateDiagramBlocks.forEach(({ block }) => {
           expect(block).not.toMatch(/<br\s*\/?>/);
         });
       });
@@ -180,7 +180,7 @@ describe('Mermaid Syntax Validation', () => {
         block.includes('stateDiagram')
       );
 
-      stateDiagramBlocks.forEach(({ block, lineStart }) => {
+      stateDiagramBlocks.forEach(({ block }) => {
         // If we see conditional transition naming, we should have choice state
         if (block.includes('_less_') || block.includes('_greater_')) {
           expect(block).toMatch(/state\s+\w+\s*<<choice>>/);
@@ -196,7 +196,7 @@ describe('Mermaid Syntax Validation', () => {
         }
 
         const blocks = extractMermaidBlocks(filePath);
-        blocks.forEach(({ block }, index) => {
+        blocks.forEach(({ block }) => {
           if (block.includes('stateDiagram')) {
             expect(block).toMatch(/stateDiagram-v2/);
           }

--- a/src/__tests__/visualization/machineMetadataGeneration.test.ts
+++ b/src/__tests__/visualization/machineMetadataGeneration.test.ts
@@ -197,7 +197,7 @@ export const healthMachine = createMachine({
         fs.writeFileSync(fullPath, content);
       }
 
-      const machineFiles = findMachineFiles(fixturesDir);
+      const _machineFiles = findMachineFiles(fixturesDir);
 
       // Devrait trouver les 3 fichiers *Machine.ts (même si nommés différemment dans le test)
       // En réalité, on cherche les fichiers qui se terminent par Machine.ts

--- a/src/__tests__/visualization/visualizationIntegration.test.ts
+++ b/src/__tests__/visualization/visualizationIntegration.test.ts
@@ -25,7 +25,7 @@ describe('Visualization System Integration', () => {
           cwd: path.join(__dirname, '../../..'),
           stdio: 'pipe',
         });
-      } catch (error) {
+      } catch (_error) {
         // Le script peut échouer en test si les machines n'existent pas encore
         // On skip ce test dans ce cas
         if (!fs.existsSync(metadataPath)) {

--- a/src/api/controllers/risController.ts
+++ b/src/api/controllers/risController.ts
@@ -230,7 +230,7 @@ export async function updateApplication(
   const changes: Array<{ field: string; oldValue: any; newValue: any }> = [];
 
   // Update fields
-  const { expectedVersion, ...updates } = request.body;
+  const { expectedVersion: _expectedVersion, ...updates } = request.body;
   Object.keys(updates).forEach((key) => {
     const oldValue = (application as any)[key];
     const newValue = (updates as any)[key];

--- a/src/api/routes/risRoutes.ts
+++ b/src/api/routes/risRoutes.ts
@@ -3,7 +3,7 @@
  */
 
 import { FastifyInstance } from 'fastify';
-import { authenticate, authorize } from '../../middleware/auth';
+import { authenticate } from '../../middleware/auth';
 import * as risController from '../controllers/risController';
 
 export default async function risRoutes(server: FastifyInstance) {

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -12,9 +12,8 @@ import swagger from '@fastify/swagger';
 import swaggerUi from '@fastify/swagger-ui';
 
 import { initializeDatabase, closeDatabase } from '../database/data-source';
-import { closeCacheConnections, redisClient } from '../cache/cacheService';
+import { closeCacheConnections } from '../cache/cacheService';
 import { closeQueue } from '../queue/conversionQueue';
-import { authenticate } from '../middleware/auth';
 
 // Import routes
 import risRoutes from './routes/risRoutes';

--- a/src/workflows/environment/permisEnvironnementMachine.ts
+++ b/src/workflows/environment/permisEnvironnementMachine.ts
@@ -22,7 +22,7 @@ interface PermisEnvironnementContext {
 }
 
 export const permisEnvironnementMachine = createMachine({
-  id: 'permisEnvironnement',
+  id: 'permisEnvironnementBase',
   initial: 'inactif',
 
   schemas: {


### PR DESCRIPTION
- Rename permisEnvironnementMachine ID in environment/ to 'permisEnvironnementBase' to avoid conflict with ecologie/ version
- Remove unused imports: redisClient, authenticate from server.ts
- Remove unused import: authorize from risRoutes.ts
- Prefix unused variables with underscore to follow ESLint conventions:
  - expectedVersion in risController.ts
  - error in visualizationIntegration.test.ts
  - machineFiles in machineMetadataGeneration.test.ts
  - Unused forEach parameters in mermaid-syntax.test.ts

This resolves the test failure where 131 machine IDs resulted in only 130 unique IDs. All visualization integration tests now pass successfully.