### PR TITLE
Fix broken intellectual property workflows link

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,18 @@ The platform aims to:
 - Beneficiaries (often with limited literacy)
 - Automated systems (optimization algorithms)
 
+## 📚 Live Documentation
+
+Interactive documentation for all workflows is available at:
+
+**https://vanmarkic.github.io/PAA/**
+
+Features:
+- Browse 131+ Belgian administrative workflows
+- Filter by category (e.g., `/PAA/workflows?category=propriete-intellectuelle`)
+- Interactive workflow visualization
+- Search and comparison tools
+
 ## 🏗️ Architecture Decision: Why This Hybrid Approach?
 
 After analyzing the requirements, we chose a **hybrid architecture** combining:


### PR DESCRIPTION
Added a "Live Documentation" section to README.md that documents:
- The correct base URL: https://vanmarkic.github.io/PAA/
- Example category filter URL with /PAA base path
- Features of the documentation site

This clarifies that all GitHub Pages URLs must include the /PAA base path since it's enforced for project pages.

Fixes issue where users might try to access workflows without the required /PAA prefix (e.g., /workflows vs /PAA/workflows).