### PR TITLE
Fix URLs for Astro GitHub Pages

### DIFF
--- a/docs-astro/src/components/WorkflowWizard.tsx
+++ b/docs-astro/src/components/WorkflowWizard.tsx
@@ -13,6 +13,7 @@ interface Machine {
 
 interface WorkflowWizardProps {
   machines: Machine[];
+  baseUrl?: string;
 }
 
 type Step = 'category' | 'situation' | 'urgency' | 'results';
@@ -30,7 +31,7 @@ const categoryMapping: Record<string, string[]> = {
   'immigration': ['Immigration', 'Séjour', 'Naturalisation']
 };
 
-export default function WorkflowWizard({ machines }: WorkflowWizardProps) {
+export default function WorkflowWizard({ machines, baseUrl = '/' }: WorkflowWizardProps) {
   const [currentStep, setCurrentStep] = useState<Step>('category');
   const [selectedCategory, setSelectedCategory] = useState('');
   const [selectedSituation, setSelectedSituation] = useState('');
@@ -255,7 +256,7 @@ export default function WorkflowWizard({ machines }: WorkflowWizardProps) {
               {results.map(machine => (
                 <a
                   key={machine.id}
-                  href={`/workflows/${machine.id}`}
+                  href={`${baseUrl}workflows/${machine.id}`}
                   className="block p-4 bg-white border border-gray-200 rounded-lg hover:border-purple-500 hover:shadow-md transition-all"
                 >
                   <div className="flex items-start justify-between">
@@ -296,7 +297,7 @@ export default function WorkflowWizard({ machines }: WorkflowWizardProps) {
               Nouvelle Recherche
             </button>
             <a
-              href="/benefits"
+              href={`${baseUrl}benefits`}
               className="px-6 py-3 bg-white text-purple-600 border border-purple-600 rounded-lg hover:bg-purple-50 transition-colors"
             >
               Voir Toutes les Prestations

--- a/docs-astro/src/layouts/Layout.astro
+++ b/docs-astro/src/layouts/Layout.astro
@@ -38,8 +38,8 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
     <meta property="twitter:description" content={description} />
 
     <!-- Favicon -->
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <link rel="alternate icon" href="/favicon.ico" />
+    <link rel="icon" type="image/svg+xml" href={`${import.meta.env.BASE_URL}favicon.svg`} />
+    <link rel="alternate icon" href={`${import.meta.env.BASE_URL}favicon.ico`} />
 
     <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/docs-astro/src/pages/benefits.astro
+++ b/docs-astro/src/pages/benefits.astro
@@ -89,7 +89,7 @@ const featuredBenefits = [
     <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6 mb-12">
       <h2 class="text-xl font-semibold text-gray-900 mb-4">Recherche Rapide</h2>
       <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
-        <a href="/wizard" class="p-4 bg-purple-50 text-purple-700 rounded-lg hover:bg-purple-100 transition-colors text-center">
+        <a href={`${import.meta.env.BASE_URL}wizard`} class="p-4 bg-purple-50 text-purple-700 rounded-lg hover:bg-purple-100 transition-colors text-center">
           <svg class="w-8 h-8 mx-auto mb-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
           </svg>
@@ -103,7 +103,7 @@ const featuredBenefits = [
           <div class="font-medium">Calculateur</div>
           <div class="text-sm mt-1">Estimez vos aides</div>
         </a>
-        <a href="/comparison" class="p-4 bg-green-50 text-green-700 rounded-lg hover:bg-green-100 transition-colors text-center">
+        <a href={`${import.meta.env.BASE_URL}comparison`} class="p-4 bg-green-50 text-green-700 rounded-lg hover:bg-green-100 transition-colors text-center">
           <svg class="w-8 h-8 mx-auto mb-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"></path>
           </svg>
@@ -123,7 +123,7 @@ const featuredBenefits = [
             <p class="text-gray-600 mb-4">{benefit.description}</p>
             <div class="flex items-center justify-between">
               <span class="text-2xl font-bold text-purple-600">{benefit.amount}</span>
-              <a href={`/workflows?category=${benefit.category}`} class="text-purple-600 hover:text-purple-700 font-medium">
+              <a href={`${import.meta.env.BASE_URL}workflows?category=${benefit.category}`} class="text-purple-600 hover:text-purple-700 font-medium">
                 En savoir plus →
               </a>
             </div>
@@ -180,13 +180,13 @@ const featuredBenefits = [
             <div class="border-t pt-4">
               <div class="space-y-2">
                 {category.workflows.slice(0, 3).map((workflow: any) => (
-                  <a href={`/workflows/${workflow.id}`} class="block text-sm text-gray-700 hover:text-purple-600 transition-colors">
+                  <a href={`${import.meta.env.BASE_URL}workflows/${workflow.id}`} class="block text-sm text-gray-700 hover:text-purple-600 transition-colors">
                     → {workflow.name}
                   </a>
                 ))}
               </div>
               {category.workflows.length > 3 && (
-                <a href={`/workflows?category=${category.id}`} class="block mt-3 text-sm font-medium text-purple-600 hover:text-purple-700">
+                <a href={`${import.meta.env.BASE_URL}workflows?category=${category.id}`} class="block mt-3 text-sm font-medium text-purple-600 hover:text-purple-700">
                   Voir tous ({category.workflows.length})
                 </a>
               )}
@@ -204,7 +204,7 @@ const featuredBenefits = [
           Nos conseillers sont là pour vous accompagner dans vos démarches. Prenez rendez-vous dans votre CPAS local ou utilisez notre assistant en ligne.
         </p>
         <div class="flex flex-wrap gap-4">
-          <a href="/wizard" class="inline-block px-6 py-3 bg-white text-blue-600 font-semibold rounded-lg hover:bg-blue-50 transition-colors">
+          <a href={`${import.meta.env.BASE_URL}wizard`} class="inline-block px-6 py-3 bg-white text-blue-600 font-semibold rounded-lg hover:bg-blue-50 transition-colors">
             Assistant en Ligne
           </a>
           <a href="#contact" class="inline-block px-6 py-3 bg-blue-600 text-white font-semibold rounded-lg hover:bg-blue-800 transition-colors">

--- a/docs-astro/src/pages/index.astro
+++ b/docs-astro/src/pages/index.astro
@@ -41,13 +41,13 @@ const categoryStats = categories.map((cat: string) => ({
 
       <!-- Role-Based Navigation -->
       <div class="flex flex-wrap justify-center gap-4 mb-8">
-        <a href="/wizard" class="px-6 py-3 bg-gradient-to-r from-purple-500 to-purple-700 text-white rounded-lg hover:shadow-lg transition-all">
+        <a href={`${import.meta.env.BASE_URL}wizard`} class="px-6 py-3 bg-gradient-to-r from-purple-500 to-purple-700 text-white rounded-lg hover:shadow-lg transition-all">
           Trouver une Prestation
         </a>
-        <a href="/benefits" class="px-6 py-3 bg-white text-purple-600 border-2 border-purple-500 rounded-lg hover:bg-purple-50 transition-all">
+        <a href={`${import.meta.env.BASE_URL}benefits`} class="px-6 py-3 bg-white text-purple-600 border-2 border-purple-500 rounded-lg hover:bg-purple-50 transition-all">
           Guide des Prestations
         </a>
-        <a href="/developer" class="px-6 py-3 bg-white text-gray-700 border border-gray-300 rounded-lg hover:bg-gray-50 transition-all">
+        <a href={`${import.meta.env.BASE_URL}developer`} class="px-6 py-3 bg-white text-gray-700 border border-gray-300 rounded-lg hover:bg-gray-50 transition-all">
           Documentation Dev
         </a>
       </div>
@@ -101,7 +101,7 @@ const categoryStats = categories.map((cat: string) => ({
       <h2 class="text-2xl font-bold text-gray-900 mb-6">Explorer par Catégorie</h2>
       <div class="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-4">
         {categoryStats.map((cat: any) => (
-          <a href={`/workflows?category=${cat.id}`} class="bg-white p-4 rounded-lg border border-gray-200 hover:border-purple-500 hover:shadow-md transition-all">
+          <a href={`${import.meta.env.BASE_URL}workflows?category=${cat.id}`} class="bg-white p-4 rounded-lg border border-gray-200 hover:border-purple-500 hover:shadow-md transition-all">
             <div class="text-lg font-semibold text-gray-900">{cat.name}</div>
             <div class="text-sm text-gray-600">{cat.count} workflows</div>
           </a>
@@ -114,7 +114,7 @@ const categoryStats = categories.map((cat: string) => ({
       <h2 class="text-2xl font-bold text-gray-900 mb-6">Workflows Populaires</h2>
       <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
         {machines.slice(0, 6).map((machine: any) => (
-          <a href={`/workflows/${machine.id}`} class="bg-white rounded-lg border border-gray-200 hover:border-purple-500 hover:shadow-lg transition-all p-6">
+          <a href={`${import.meta.env.BASE_URL}workflows/${machine.id}`} class="bg-white rounded-lg border border-gray-200 hover:border-purple-500 hover:shadow-lg transition-all p-6">
             <div class="mb-4">
               <span class="inline-block px-3 py-1 bg-purple-100 text-purple-700 text-xs font-medium rounded-full">
                 {machine.category}
@@ -137,7 +137,7 @@ const categoryStats = categories.map((cat: string) => ({
       <p class="mb-6 max-w-2xl mx-auto">
         Utilisez notre assistant intelligent pour trouver rapidement la prestation ou le workflow dont vous avez besoin.
       </p>
-      <a href="/wizard" class="inline-block px-8 py-3 bg-white text-purple-600 font-semibold rounded-lg hover:bg-gray-100 transition-colors">
+      <a href={`${import.meta.env.BASE_URL}wizard`} class="inline-block px-8 py-3 bg-white text-purple-600 font-semibold rounded-lg hover:bg-gray-100 transition-colors">
         Démarrer l'Assistant
       </a>
     </div>

--- a/docs-astro/src/pages/wizard.astro
+++ b/docs-astro/src/pages/wizard.astro
@@ -18,7 +18,7 @@ const metadata = await loadMachinesMetadata();
     </div>
 
     <!-- React Island for Interactive Wizard -->
-    <WorkflowWizard machines={metadata.machines} client:load />
+    <WorkflowWizard machines={metadata.machines} baseUrl={import.meta.env.BASE_URL} client:load />
 
     <!-- Static FAQ Section -->
     <div class="mt-16">
@@ -76,7 +76,7 @@ const metadata = await loadMachinesMetadata();
         <a href="#contact" class="inline-block px-6 py-3 bg-white text-purple-600 font-semibold rounded-lg hover:bg-gray-100 transition-colors">
           Contacter un Conseiller
         </a>
-        <a href="/benefits" class="inline-block px-6 py-3 bg-purple-600 text-white font-semibold rounded-lg hover:bg-purple-800 transition-colors">
+        <a href={`${import.meta.env.BASE_URL}benefits`} class="inline-block px-6 py-3 bg-purple-600 text-white font-semibold rounded-lg hover:bg-purple-800 transition-colors">
           Voir Toutes les Prestations
         </a>
       </div>

--- a/docs-astro/src/pages/workflows/index.astro
+++ b/docs-astro/src/pages/workflows/index.astro
@@ -35,7 +35,7 @@ const machinesByCategory = filteredMachines.reduce((acc: any, machine: any) => {
       <p class="text-xl text-gray-600">
         {filteredMachines.length} workflows disponibles
         {selectedCategory && (
-          <a href="/workflows" class="ml-2 text-purple-600 hover:text-purple-700">
+          <a href={`${import.meta.env.BASE_URL}workflows`} class="ml-2 text-purple-600 hover:text-purple-700">
             (voir tous)
           </a>
         )}
@@ -47,14 +47,14 @@ const machinesByCategory = filteredMachines.reduce((acc: any, machine: any) => {
       <div class="flex items-center justify-between mb-4">
         <h2 class="font-semibold text-gray-900">Filtrer par catégorie</h2>
         {selectedCategory && (
-          <a href="/workflows" class="text-sm text-purple-600 hover:text-purple-700">
+          <a href={`${import.meta.env.BASE_URL}workflows`} class="text-sm text-purple-600 hover:text-purple-700">
             Effacer le filtre
           </a>
         )}
       </div>
       <div class="flex flex-wrap gap-2">
         <a
-          href="/workflows"
+          href={`${import.meta.env.BASE_URL}workflows`}
           class={`px-4 py-2 rounded-lg transition-colors ${
             !selectedCategory
               ? 'bg-purple-100 text-purple-700 border-2 border-purple-500'
@@ -67,7 +67,7 @@ const machinesByCategory = filteredMachines.reduce((acc: any, machine: any) => {
           const count = machines.filter((m: any) => m.category === cat).length;
           return (
             <a
-              href={`/workflows?category=${cat}`}
+              href={`${import.meta.env.BASE_URL}workflows?category=${cat}`}
               class={`px-4 py-2 rounded-lg transition-colors ${
                 selectedCategory === cat
                   ? 'bg-purple-100 text-purple-700 border-2 border-purple-500'
@@ -96,7 +96,7 @@ const machinesByCategory = filteredMachines.reduce((acc: any, machine: any) => {
         <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
           {categoryMachines.map((machine: any) => (
             <a
-              href={`/workflows/${machine.id}`}
+              href={`${import.meta.env.BASE_URL}workflows/${machine.id}`}
               class="bg-white rounded-lg border border-gray-200 p-6 hover:border-purple-500 hover:shadow-lg transition-all"
             >
               <h3 class="text-lg font-semibold text-gray-900 mb-2">{machine.name}</h3>
@@ -136,10 +136,10 @@ const machinesByCategory = filteredMachines.reduce((acc: any, machine: any) => {
         Utilisez notre assistant intelligent ou notre outil de comparaison pour trouver le workflow qui correspond à vos besoins.
       </p>
       <div class="flex justify-center gap-4">
-        <a href="/wizard" class="inline-block px-8 py-3 bg-white text-purple-600 font-semibold rounded-lg hover:bg-gray-100 transition-colors">
+        <a href={`${import.meta.env.BASE_URL}wizard`} class="inline-block px-8 py-3 bg-white text-purple-600 font-semibold rounded-lg hover:bg-gray-100 transition-colors">
           Assistant de Recherche
         </a>
-        <a href="/comparison" class="inline-block px-8 py-3 bg-purple-600 text-white font-semibold rounded-lg hover:bg-purple-800 transition-colors">
+        <a href={`${import.meta.env.BASE_URL}comparison`} class="inline-block px-8 py-3 bg-purple-600 text-white font-semibold rounded-lg hover:bg-purple-800 transition-colors">
           Comparer des Workflows
         </a>
       </div>


### PR DESCRIPTION
All hardcoded absolute paths (e.g., /workflows, /wizard, /benefits) have been updated to use import.meta.env.BASE_URL to properly work with the /PAA/ base path on GitHub Pages (https://vanmarkic.github.io/PAA/).

Changes:
- index.astro: Updated all navigation and category links
- workflows/index.astro: Fixed workflow and category filter links
- benefits.astro: Updated quick search and workflow links
- wizard.astro: Fixed benefits link and passed baseUrl to React component
- WorkflowWizard.tsx: Added baseUrl prop and updated all hrefs
- Layout.astro: Fixed favicon paths to use BASE_URL

This ensures all links work correctly both in development (/) and production (/PAA/) environments.