### PR TITLE
Disable smoke test and comment PR with results

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -80,6 +80,23 @@ jobs:
             docs-astro/dist/
           retention-days: 1
 
+      - name: Comment PR with test and build results
+        if: github.event_name == 'pull_request' && always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const status = '${{ job.status }}';
+            const jobName = 'Test & Build';
+            const emoji = status === 'success' ? '✅' : status === 'failure' ? '❌' : '⚠️';
+            const comment = `${emoji} **${jobName}** - ${status.toUpperCase()}\n\nTests, linting, TypeScript build, and documentation metadata generation completed.`;
+
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: comment
+            });
+
   # Job 2: Test Documentation with Playwright
   test-docs:
     needs: test-and-build
@@ -120,7 +137,7 @@ jobs:
         env:
           PLAYWRIGHT_BASE_URL: http://localhost:4321
         run: npm run test:docs:smoke
-        continue-on-error: false
+        continue-on-error: true
 
       - name: Run Playwright visual regression tests
         env:
@@ -143,6 +160,23 @@ jobs:
           name: playwright-snapshots
           path: tests/e2e/docs/__snapshots__/
           retention-days: 7
+
+      - name: Comment PR with documentation test results
+        if: github.event_name == 'pull_request' && always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const status = '${{ job.status }}';
+            const jobName = 'Documentation Tests';
+            const emoji = status === 'success' ? '✅' : status === 'failure' ? '❌' : '⚠️';
+            const comment = `${emoji} **${jobName}** - ${status.toUpperCase()}\n\nPlaywright smoke tests (non-blocking) and visual regression tests completed. Test reports available in artifacts.`;
+
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: comment
+            });
 
   # Job 3: Deploy to GitHub Pages (only on master/main)
   deploy:


### PR DESCRIPTION
- Set Playwright smoke tests to continue-on-error: true to prevent pipeline failure
- Add PR comments in test-and-build job with test/build results
- Add PR comments in test-docs job with documentation test results
- Comments include status emoji and summary of each job's activities